### PR TITLE
Clean up scripts and enforce flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/app.py
+++ b/app.py
@@ -1,10 +1,8 @@
 import streamlit as st
 import geopandas as gpd
 import rasterio
-import numpy as np
 from shapely.geometry import LineString, Point
 import matplotlib.pyplot as plt
-import os
 from tempfile import NamedTemporaryFile
 
 st.set_page_config(
@@ -14,6 +12,7 @@ st.set_page_config(
 )
 
 ADA_SLOPE_THRESHOLD = 0.05  # 5%
+
 
 def sample_elevation(points_gdf, dem_path):
     with rasterio.open(dem_path) as src:
@@ -35,6 +34,7 @@ def sample_elevation(points_gdf, dem_path):
         points_gdf = points_gdf.to_crs("EPSG:26917")
 
     return points_gdf
+
 
 def compute_smoothed_slopes(points_gdf, window_size=3, slope_threshold=ADA_SLOPE_THRESHOLD):
     """Compute slope segments with a sliding window of *window_size* points."""
@@ -87,6 +87,7 @@ def compute_smoothed_slopes(points_gdf, window_size=3, slope_threshold=ADA_SLOPE
         "geometry": segments
     }, crs=points_gdf.crs)
 
+
 def render_map(gdf_slopes):
     fig, ax = plt.subplots(figsize=(12, 8))
     gdf_slopes[gdf_slopes['ada_compliant']].plot(
@@ -99,6 +100,7 @@ def render_map(gdf_slopes):
     plt.axis('off')
     plt.tight_layout()
     st.pyplot(fig)
+
 
 def main():
     st.title("🦽 ADA Slope Compliance Tool")
@@ -161,6 +163,6 @@ def main():
     else:
         st.info("Upload data and click Compute to begin.")
 
+
 if __name__ == "__main__":
     main()
-

--- a/processing_utils.py
+++ b/processing_utils.py
@@ -6,6 +6,7 @@ from shapely.geometry import LineString
 
 ADA_SLOPE_THRESHOLD = 0.05  # 5%
 
+
 def sample_elevation_at_points(points_gdf, dem_path):
     with rasterio.open(dem_path) as src:
         # Reproject to match raster CRS
@@ -28,6 +29,7 @@ def sample_elevation_at_points(points_gdf, dem_path):
         points_gdf = points_gdf.to_crs("EPSG:26917")
 
     return points_gdf
+
 
 def compute_slope_segments(points_gdf):
     """
@@ -77,4 +79,3 @@ def compute_slope_segments(points_gdf):
         "ada_compliant": compliance,
         "geometry": segments
     }, crs=points_gdf.crs)
-

--- a/scripts/check_elevation.py
+++ b/scripts/check_elevation.py
@@ -1,5 +1,6 @@
 import rasterio
 
+
 def inspect_raster(path):
     """Inspect the raster file to check it's properties."""
     with rasterio.open(path) as src:
@@ -11,10 +12,11 @@ def inspect_raster(path):
         print(f" - Bands: {src.count}")
         print(f" - Data Type: {src.dtypes[0]}")
 
-        #Centering the pixel values
+    # Centering the pixel values
         row, col = src.height // 2, src.width // 2
         value = src.read(1)[row, col]
-        print(f" - Sample elevation at center: {value} meters")
+    print(f" - Sample elevation at center: {value} meters")
+
 
 if __name__ == "__main__":
     inspect_raster("data/raw/USGS_13_n31w085_20230215.tif")

--- a/scripts/check_paths.py
+++ b/scripts/check_paths.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 
+
 def inspect_paths(path_fp):
     # Load the path dataset (GeoJSON) using GeoPandas
     # Each row in this GeoDataFrame represents a geographic feature, like a footpath or sidewalk
@@ -26,6 +27,7 @@ def inspect_paths(path_fp):
     # Step 4: Display a sample path geometry to verify structure
     print("\nSample LineString geometry:")
     print(gdf.geometry.iloc[0])
+
 
 if __name__ == "__main__":
     # Main entry point for standalone script execution

--- a/scripts/checkfiles.py
+++ b/scripts/checkfiles.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import rasterio
 
+
 def check_crs_consistency(raster_fp, points_fp, elevation_points_fp):
     # Load raster
     with rasterio.open(raster_fp) as raster:
@@ -13,6 +14,7 @@ def check_crs_consistency(raster_fp, points_fp, elevation_points_fp):
     # Load output points with elevation
     gdf_elevated = gpd.read_file(elevation_points_fp)
     print(f"Elevation-Sampled Points CRS: {gdf_elevated.crs.to_string()}")
+
 
 if __name__ == "__main__":
     check_crs_consistency(

--- a/scripts/compute_slope.py
+++ b/scripts/compute_slope.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 
 ADA_SLOPE_THRESHOLD = 0.05  # ADA compliance: 5% max slope
 
+
 def compute_slopes_by_path(points_fp, output_fp):
     """
     Computes slope segments between adjacent elevation points, grouped by path_id,
@@ -60,6 +61,7 @@ def compute_slopes_by_path(points_fp, output_fp):
 
     return gdf_slopes
 
+
 def plot_slope_segments(gdf):
     fig, ax = plt.subplots(figsize=(12, 10))
     gdf[gdf['ada_compliant']].plot(ax=ax, color='green', linewidth=1, label='ADA Compliant')
@@ -76,6 +78,7 @@ def plot_slope_segments(gdf):
     plt.axis('off')
     plt.savefig("outputs/maps/fsu_slope_gradient.png", dpi=300)
     plt.show()
+
 
 if __name__ == "__main__":
     output_fp = "data/processed/fsu_slope_segments.geojson"

--- a/scripts/resample_paths.py
+++ b/scripts/resample_paths.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
-from shapely.geometry import LineString, Point
+from shapely.geometry import LineString
+
 
 def generate_points_along_line(line, distance_interval):
     """
@@ -14,6 +15,7 @@ def generate_points_along_line(line, distance_interval):
         points.append(point)
 
     return points
+
 
 def resample_paths_to_points(path_fp, output_fp, interval_meters=5):
     """
@@ -45,6 +47,7 @@ def resample_paths_to_points(path_fp, output_fp, interval_meters=5):
     gdf_points.to_file(output_fp, driver="GeoJSON")
     print(f"Resampled points with path IDs saved to: {output_fp}")
     print(f"Total points generated: {len(gdf_points)}")
+
 
 if __name__ == "__main__":
     resample_paths_to_points(

--- a/scripts/sample_elevation.py
+++ b/scripts/sample_elevation.py
@@ -1,9 +1,10 @@
 import geopandas as gpd
 import rasterio
 
+
 def sample_elevation_at_points(points_fp, raster_fp, output_fp):
     """
-    Loads a GeoJSON of point features and samples elevation values 
+    Loads a GeoJSON of point features and samples elevation values
     from a DEM raster. The elevation is added to each point and saved
     to a new GeoJSON file.
     """
@@ -36,6 +37,7 @@ def sample_elevation_at_points(points_fp, raster_fp, output_fp):
     # Step 6: Save the output GeoJSON file with new elevation data
     gdf_points.to_file(output_fp, driver="GeoJSON")
     print(f"Elevation-sampled points saved to: {output_fp}")
+
 
 if __name__ == "__main__":
     sample_elevation_at_points(

--- a/scripts/summarize_slope_data.py
+++ b/scripts/summarize_slope_data.py
@@ -2,6 +2,7 @@ import geopandas as gpd
 import json
 import os
 
+
 def summarize_slope_compliance(slope_fp, output_md_fp=None, output_json_fp=None):
     """
     Loads a GeoJSON file with slope segment data and computes ADA compliance summary.
@@ -49,7 +50,8 @@ def summarize_slope_compliance(slope_fp, output_md_fp=None, output_json_fp=None)
         os.makedirs(os.path.dirname(output_json_fp), exist_ok=True)
         with open(output_json_fp, "w") as f:
             json.dump(summary, f, indent=4)
-        print("JSON summary saved to:", output_json_fp)
+    print("JSON summary saved to:", output_json_fp)
+
 
 if __name__ == "__main__":
     summarize_slope_compliance(

--- a/scripts/visualize_paths_and_points.py
+++ b/scripts/visualize_paths_and_points.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import matplotlib.pyplot as plt
 
+
 def plot_paths_and_points(paths_fp, points_fp):
     """
     Loads the pedestrian paths and resampled points,
@@ -36,6 +37,7 @@ def plot_paths_and_points(paths_fp, points_fp):
 
     # Display the plot interactively
     plt.show()
+
 
 if __name__ == "__main__":
     # Entry point for running the script

--- a/tests/test_processing_utils.py
+++ b/tests/test_processing_utils.py
@@ -4,8 +4,8 @@ import geopandas as gpd
 from shapely.geometry import Point
 import pytest
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from processing_utils import compute_slope_segments
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+from processing_utils import compute_slope_segments  # noqa: E402
 
 
 def test_compute_slope_segments_basic():


### PR DESCRIPTION
## Summary
- remove stray shell prompt text from scripts
- add newline endings and spacing for PEP8 compliance
- create flake8 config and clean up imports

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68430a8460548323b6d8e8f51708d29c