### PR TITLE
Gracefully handle empty groups

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,6 +49,7 @@ def compute_smoothed_slopes(points_gdf, window_size=3, slope_threshold=ADA_SLOPE
 
     half_window = window_size // 2
     if 'path_id' in points_gdf.columns:
+        points_gdf = points_gdf.dropna(subset=['path_id'])
         grouped = points_gdf.groupby('path_id')
     else:
         grouped = [(None, points_gdf)]
@@ -65,9 +66,8 @@ def compute_smoothed_slopes(points_gdf, window_size=3, slope_threshold=ADA_SLOPE
         group = group.sort_index().reset_index(drop=True)
 
         if len(group) < window_size:
-            raise ValueError(
-                f"Group {group_id} has {len(group)} point(s), fewer than window_size {window_size}"
-            )
+            # Skip groups that do not have enough points for the smoothing window
+            continue
 
         for i in range(half_window, len(group) - half_window):
             window = group.iloc[i - half_window:i + half_window + 1]

--- a/processing_utils.py
+++ b/processing_utils.py
@@ -65,6 +65,7 @@ def compute_slope_segments(points_gdf):
         points_gdf = points_gdf.to_crs("EPSG:26917")
 
     if 'path_id' in points_gdf.columns:
+        points_gdf = points_gdf.dropna(subset=['path_id'])
         grouped = points_gdf.groupby('path_id')
     else:
         grouped = [(None, points_gdf)]

--- a/tests/test_processing_utils.py
+++ b/tests/test_processing_utils.py
@@ -81,5 +81,5 @@ def test_compute_smoothed_slopes_insufficient_points():
         crs="EPSG:26917",
     )
 
-    with pytest.raises(ValueError):
-        compute_smoothed_slopes(gdf, window_size=5)
+    result = compute_smoothed_slopes(gdf, window_size=5)
+    assert result.empty


### PR DESCRIPTION
## Summary
- drop invalid `path_id`s before grouping
- skip groups with too few points instead of raising
- adjust tests expecting graceful handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484bb29b508323aa5952bc86924641